### PR TITLE
feat: legend titles preformatted as bold and left-aligned

### DIFF
--- a/R/parse_df.R
+++ b/R/parse_df.R
@@ -416,7 +416,7 @@ theme_categorical <- function(show_legend = TRUE, show_legend_titles = FALSE, le
       axis.title.x = element_blank(),
       axis.title.y = element_text(angle = 0),
       legend.key.size = ggplot2::unit(legend_key_size, "line"),
-      legend.title = if(show_legend_titles) element_text(size = legend_title_size) else element_blank(),
+      legend.title = if(show_legend_titles) element_text(size = legend_title_size, face = "bold", hjust = 0) else element_blank(),
       legend.justification = "left",
       legend.text = element_text(size = legend_text_size),
       legend.position = if(show_legend) legend_position else "none"

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,7 +60,7 @@ gg1d_plot(
   df, 
   col_id = "ID", 
   col_sort = "Glasses", 
-  interactive = FALSE, legend_nrow = 2, verbose = FALSE
+  interactive = FALSE, legend_nrow = 2, verbose = FALSE, show_legend_titles = TRUE
 )
 ```
 


### PR DESCRIPTION
Still turned off by default, but now when turned on they should look a bit nicer.

Legends are usually still overlapping - so consider adding an option to collect legends together and a message advising end-users to use this option when showing legend titles - as per #4 